### PR TITLE
set tinkr to main branch

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,8 +1,7 @@
 [
     {
         "package": "tinkr",
-        "url": "https://github.com/ropensci/tinkr",
-        "branch": "maelle-patch-1"
+        "url": "https://github.com/ropensci/tinkr"
     },
     {
         "package": "xslt",


### PR DESCRIPTION
I've merged in @maelle's patch and this will allow the main branch to once again be served to the lessons. 

When I release to CRAN, I will make a PR here to set this to use the released version and then we will hopefully never have to do this again. 